### PR TITLE
fix cookie date for compatibility with IE. 

### DIFF
--- a/dist/kb/common/cookie.js
+++ b/dist/kb/common/cookie.js
@@ -140,7 +140,6 @@ define([], function () {
                     }).join(';');
                     cookieString = [encodeURIComponent(cookie.name), [encodeURIComponent(cookie.value), propString].join(';')].join('=');                    
                 }
-                console.log('Setting cookie: ', cookieString);
                 this.doc.cookie = cookieString;
             }
         },

--- a/dist/kb/common/cookie.js
+++ b/dist/kb/common/cookie.js
@@ -78,9 +78,12 @@ define([], function () {
                     switch (vEnd.constructor) {
                         case Number:
                             if (vEnd === Infinity) {
-                                sExpires = 'Fri, 31 Dec 9999 23:59:59 GMT';
+                                sExpires = (new Date('9999-12-31T23:59:59Z')).toUTCString(); 
                             } else {
                                 maxAge = vEnd;
+                                // set both expires and max-age. Max-age because it is more accurate
+                                // and expires because it is more compatible (well, with IE).
+                                sExpires = (new Date((new Date()).getTime() + vEnd*1000)).toUTCString()
                             }
                             break;
                         case String:
@@ -137,6 +140,7 @@ define([], function () {
                     }).join(';');
                     cookieString = [encodeURIComponent(cookie.name), [encodeURIComponent(cookie.value), propString].join(';')].join('=');                    
                 }
+                console.log('Setting cookie: ', cookieString);
                 this.doc.cookie = cookieString;
             }
         },
@@ -147,7 +151,7 @@ define([], function () {
                     value: '*',
                     domain: sDomain,
                     path: sPath,
-                    expires: '01 Jan 1970 00:00:00 GMT'
+                    expires:  (new Date('1970-01-01T00:00:00Z')).toUTCString()
                 });
             }
         },

--- a/src/js/cookie.js
+++ b/src/js/cookie.js
@@ -140,7 +140,6 @@ define([], function () {
                     }).join(';');
                     cookieString = [encodeURIComponent(cookie.name), [encodeURIComponent(cookie.value), propString].join(';')].join('=');                    
                 }
-                console.log('Setting cookie: ', cookieString);
                 this.doc.cookie = cookieString;
             }
         },

--- a/src/js/cookie.js
+++ b/src/js/cookie.js
@@ -78,9 +78,12 @@ define([], function () {
                     switch (vEnd.constructor) {
                         case Number:
                             if (vEnd === Infinity) {
-                                sExpires = 'Fri, 31 Dec 9999 23:59:59 GMT';
+                                sExpires = (new Date('9999-12-31T23:59:59Z')).toUTCString(); 
                             } else {
                                 maxAge = vEnd;
+                                // set both expires and max-age. Max-age because it is more accurate
+                                // and expires because it is more compatible (well, with IE).
+                                sExpires = (new Date((new Date()).getTime() + vEnd*1000)).toUTCString()
                             }
                             break;
                         case String:
@@ -137,6 +140,7 @@ define([], function () {
                     }).join(';');
                     cookieString = [encodeURIComponent(cookie.name), [encodeURIComponent(cookie.value), propString].join(';')].join('=');                    
                 }
+                console.log('Setting cookie: ', cookieString);
                 this.doc.cookie = cookieString;
             }
         },
@@ -147,7 +151,7 @@ define([], function () {
                     value: '*',
                     domain: sDomain,
                     path: sPath,
-                    expires: '01 Jan 1970 00:00:00 GMT'
+                    expires:  (new Date('1970-01-01T00:00:00Z')).toUTCString()
                 });
             }
         },


### PR DESCRIPTION
A missing day of week field causes IE to treat the expires field as missing, and it becomes a session
cookie. Until the recent ".kbase.us" cookie fix this bug had no effect because the cookie was simultaneously invalidated (setting to "*").
