### PR TITLE
Remove old references to kbase_narr_session

### DIFF
--- a/dist/kb/common/session.js
+++ b/dist/kb/common/session.js
@@ -31,7 +31,7 @@ define([
              * The canonical kbase session object, based on the kbase session
              * cookie, but removing a duplicated field and adding the parsed
              * token.
-             * 
+             *
              * @typedef {Object} SessionObject
              * @property {string} user_id
              * @property {string} realname
@@ -41,13 +41,13 @@ define([
              */
 
             /**
-             * The token object as supplied by the Globus auth service. 
+             * The token object as supplied by the Globus auth service.
              * @todo: document the remainder of the fields
-             * 
+             *
              * @typedef {Object} TokenObject
              * @property {string} un
              * @property {string} expiry
-             * 
+             *
              */
 
             function getVersion() {
@@ -55,11 +55,11 @@ define([
             }
 
             /**
-             * 
+             *
              * The traditional KBase session layout, reflecting the fields set
              * in the browser cookie.
-             * 
-             * 
+             *
+             *
              * @typedef {Object} KBaseSessionObject
              * @property {string} token - The Globus auth token
              * @property {string} un - username as extracted from the Globus auth token
@@ -71,26 +71,26 @@ define([
              * used to uniquely identify this session amongst all other extant
              * sessions. ???
              * @todo Where is kbase_sessionid used??? Not in ui-common ..
-             * 
+             *
              */
 
 
             /**
              * An object representation of the Globus authentication token.
-             * 
+             *
              * @typedef {Object} GlobusAuthToken
-             * 
+             *
              */
 
             /**
              * Decodes a Globus authentication token, transforming the token
              * plain string into a map of field names to values.
-             * 
+             *
              * @function decodeToken
              * @private
-             * 
+             *
              * @param {string} - A globus auth token
-             * 
+             *
              * @returns {GlobusAuthToken} an object representing the decoded
              * token.
              */
@@ -110,10 +110,10 @@ define([
 
             /**
              * Determines if the session has expired by inspection of the expiry.
-             * 
+             *
              * @function hasExpired
              * @private
-             * 
+             *
              * @param {SessionObject} - a session object
              * @returns {boolean} true if the session has expired, false otherwise.
              */
@@ -138,19 +138,19 @@ define([
              * Given a session object, ensure that it is valid, to best of our
              * ability. It serves as the gateway between the externally stored
              * session cookie, and the internally stored session object.
-             * 
+             *
              * It probably should not be the responsibility of the front end
              * to front end to evaluate the session -- that should be conducted
              * by a back-end service -- but this is the way it works now.
-             * 
+             *
              * Validation consists of ensuring that the session object is complete,
              * and that it has not expired. The expiration date derives from the
-             * Globus auth token. The evaluation of this is one of my bigger 
+             * Globus auth token. The evaluation of this is one of my bigger
              * problems.
-             * 
+             *
              * @function validateSession
              * @private
-             * 
+             *
              * @param {Object} - the prospective session object
              * @returns {boolean} - if the session is valid.
              */
@@ -174,13 +174,13 @@ define([
 
             /**
              * Creates an session cookie string from the current session cookie.
-             * 
+             *
              * @todo this is not a very good encoding method; needs to be fixed
              * @todo e.g. a field value which also contains delimiters.
-             * 
+             *
              * @function makeSessionCookie
-             * @private 
-             * 
+             * @private
+             *
              * @returns {string|null} a session object formatted into a string
              * suitable for transport in a cookie.
              */
@@ -194,14 +194,13 @@ define([
             }
             /**
              * Create and set a session cookie in the browser.
-             * 
+             *
              * Adds kbase_session cookie to browser
-             * Adds kbase_narr_session to browser
              * Adds kbase_session object to local storage
-             * 
+             *
              * @function setSessionCookie
              * @private
-             * 
+             *
              * @returns {undefined} nothing
              */
             function setSessionCookie() {
@@ -210,7 +209,7 @@ define([
                     cookieManager.setItem(cookieName, cookieString, cookieMaxAge, '/');
                     if (extraCookieNames) {
                         extraCookieNames.forEach(function (cookieName) {
-                            cookieManager.setItem(cookieName, cookieString, cookieMaxAge, '/');                            
+                            cookieManager.setItem(cookieName, cookieString, cookieMaxAge, '/');
                         });
                     }
                     // Cookie.setItem(narrCookieName, cookieString, cookieMaxAge, '/');
@@ -225,11 +224,11 @@ define([
             /**
              * Forces the session object to be re-imported from the browser
              * cookie. Designed to be used by clients which want to ensure that
-             * they have the very latest session. 
-             * 
+             * they have the very latest session.
+             *
              * @function refreshSession
              * @public
-             * 
+             *
              * @returns {SessionObject} the current session object.
              */
             function refreshSession() {
@@ -241,10 +240,10 @@ define([
              * Returns the "KBase Session", for legacy usage. The legacy method
              * of accessing the session is to work directly with a session object,
              * rather than the api.
-             * 
+             *
              * @function getKBaseSesssion
              * @public
-             * 
+             *
              * @returns {KBaseSessionObject}
              */
             function getKbaseSession() {
@@ -269,19 +268,19 @@ define([
 
             /**
              * Removes all traces of of the session from the users browser
-             * 
+             *
              * @function removeSession
              * @private
-             * 
+             *
              * @returns {undefined} nothing
              */
             function removeSession() {
                 var cookies = cookieManager.getCookies();
                 cookies.forEach(function (cookie) {
-                    cookieManager.removeItem(cookie.name, '/');                    
+                    cookieManager.removeItem(cookie.name, '/');
                     cookieManager.removeItem(cookie.name, '/', '.kbase.us');
                 });
-                
+
 //                Cookie.removeItem(cookieName, '/');
 //                if (extraCookieNames) {
 //                    extraCookieNames.forEach(function (cookieName) {
@@ -299,12 +298,12 @@ define([
 
 
             /**
-             * Attempt to set the internal session object from the given 
+             * Attempt to set the internal session object from the given
              * session object.
-             * 
+             *
              * @function setSession
              * @private
-             * 
+             *
              * @param {SessionObject} obj - a session object
              * @returns {undefined}
              */
@@ -315,15 +314,15 @@ define([
                     sessionObject = null;
                 }
             }
-            
+
             /**
-             * Extract the cookie from the browser environment, parse it, and 
+             * Extract the cookie from the browser environment, parse it, and
              * validate it. This is the canonical interface betweek KBase ui
              * code and browser authentication.
-             * 
+             *
              * @function importSessionFromCookie
              * @private
-             * 
+             *
              * @returns {SessionObject|null} a kbase session object or null
              * if there is no valid session cookie.
              */
@@ -338,7 +337,7 @@ define([
                     return null;
                 }
                 sessionCookie = sessionCookies[0];
-                
+
                 // Ensure that we have the extra cookie names as well.
                 var extraCookiesOk = true;
                 extraCookieNames.forEach(function (name) {
@@ -357,7 +356,7 @@ define([
                     removeSession();
                     return null;
                 }
-                
+
                 // first pass just break out the string into fields.
                 var session = decodeToken(sessionCookie);
 
@@ -399,10 +398,10 @@ define([
             /**
              * Creates a valid standard Session Object from a raw session object
              * provided by Globus.
-             * 
+             *
              * @function importSessionFromAuthObject
              * @private
-             * 
+             *
              * @param {KBaseSessionObject} kbaseSession - the session object
              * returned from the KBase auth server
              * @returns {SessionObject|null} a validated Session Object, or null
@@ -437,20 +436,20 @@ define([
              * typedef {Object} LoginCredentials
              * @property {string} username - the username
              * @property {string} password - the password
-             * 
+             *
              */
 
             /**
              * Authenticate a user give a username and password with the kbase
              * auth service.
              * Named "login" for legacy purposes.
-             * 
+             *
              * @function login
              * @public
-             * 
+             *
              * @param {LoginCredentials} options - a authentication credentials, as would
              * be passed in from a login dialog.
-             * 
+             *
              */
             function login(options) {
                 return new Promise(function (resolve, reject) {
@@ -468,15 +467,15 @@ define([
                         //options.error('Password is empty: It is required for login');
                         return;
                     }
-                    
-                    // Convert the username to lower case, in case the user typed in 
+
+                    // Convert the username to lower case, in case the user typed in
                     // upper case letters.
                     options.username = options.username.toLowerCase();
-                    
+
 
                     // NB: the cookie param determines whether the auth service will
                     // set a cookie or not. The cookie set only includes un and kbase_sessionid.
-                    // It does not include the auth token, amazingly, which is required for all 
+                    // It does not include the auth token, amazingly, which is required for all
                     // service calls.
                     var loginParams = {
                         user_id: options.username,
@@ -591,7 +590,7 @@ define([
             }
             // Setup
 
-            
+
             // API
 
             return {

--- a/src/js/session.js
+++ b/src/js/session.js
@@ -17,7 +17,6 @@ define([
             var version = '0.2.0',
                 config = cfg || {},
                 cookieName = config.cookieName,
-                extraCookieNames = config.extraCookieNames || [],
                 useLocalStorage = config.useLocalStorage,
                 cookieMaxAge = config.cookieMaxAge || 36000,
                 loginUrl = config.loginUrl,
@@ -207,12 +206,6 @@ define([
                 if (sessionObject) {
                     var cookieString = makeSessionCookie();
                     cookieManager.setItem(cookieName, cookieString, cookieMaxAge, '/');
-                    if (extraCookieNames) {
-                        extraCookieNames.forEach(function (cookieName) {
-                            cookieManager.setItem(cookieName, cookieString, cookieMaxAge, '/');
-                        });
-                    }
-                    // Cookie.setItem(narrCookieName, cookieString, cookieMaxAge, '/');
                     var kbaseSession = makeKbaseSession();
                     // This is for compatability with the current state of the narrative ui, which uses this
                     // as a flag for being authenticated.
@@ -281,17 +274,6 @@ define([
                     cookieManager.removeItem(cookie.name, '/', '.kbase.us');
                 });
 
-//                Cookie.removeItem(cookieName, '/');
-//                if (extraCookieNames) {
-//                    extraCookieNames.forEach(function (cookieName) {
-//                        Cookie.removeItem(cookieName, '/');
-//                    });
-//                }
-                // Cookie.removeItem(cookieName, '/', 'kbase.us');
-                // Cookie.removeItem(narrCookieName, '/', 'kbase.us');
-                // Remove the localStorage session for compatability.
-                //localStorage.removeItem(cookieName);
-
                 sessionObject = null;
             }
 
@@ -337,25 +319,6 @@ define([
                     return null;
                 }
                 sessionCookie = sessionCookies[0];
-
-                // Ensure that we have the extra cookie names as well.
-                var extraCookiesOk = true;
-                extraCookieNames.forEach(function (name) {
-                    var cookies = cookieManager.getItems(name);
-                    if (!cookies || cookies.length === 0) {
-                        extraCookiesOk = false;
-                    }
-                    if (sessionCookies.length > 1) {
-                        extraCookiesOk = false;
-                    }
-                    if (cookies[0] !== sessionCookie) {
-                        extraCookiesOk = false;
-                    }
-                });
-                if (!extraCookiesOk) {
-                    removeSession();
-                    return null;
-                }
 
                 // first pass just break out the string into fields.
                 var session = decodeToken(sessionCookie);

--- a/src/js/session.js
+++ b/src/js/session.js
@@ -31,7 +31,7 @@ define([
              * The canonical kbase session object, based on the kbase session
              * cookie, but removing a duplicated field and adding the parsed
              * token.
-             * 
+             *
              * @typedef {Object} SessionObject
              * @property {string} user_id
              * @property {string} realname
@@ -41,13 +41,13 @@ define([
              */
 
             /**
-             * The token object as supplied by the Globus auth service. 
+             * The token object as supplied by the Globus auth service.
              * @todo: document the remainder of the fields
-             * 
+             *
              * @typedef {Object} TokenObject
              * @property {string} un
              * @property {string} expiry
-             * 
+             *
              */
 
             function getVersion() {
@@ -55,11 +55,11 @@ define([
             }
 
             /**
-             * 
+             *
              * The traditional KBase session layout, reflecting the fields set
              * in the browser cookie.
-             * 
-             * 
+             *
+             *
              * @typedef {Object} KBaseSessionObject
              * @property {string} token - The Globus auth token
              * @property {string} un - username as extracted from the Globus auth token
@@ -71,26 +71,26 @@ define([
              * used to uniquely identify this session amongst all other extant
              * sessions. ???
              * @todo Where is kbase_sessionid used??? Not in ui-common ..
-             * 
+             *
              */
 
 
             /**
              * An object representation of the Globus authentication token.
-             * 
+             *
              * @typedef {Object} GlobusAuthToken
-             * 
+             *
              */
 
             /**
              * Decodes a Globus authentication token, transforming the token
              * plain string into a map of field names to values.
-             * 
+             *
              * @function decodeToken
              * @private
-             * 
+             *
              * @param {string} - A globus auth token
-             * 
+             *
              * @returns {GlobusAuthToken} an object representing the decoded
              * token.
              */
@@ -110,10 +110,10 @@ define([
 
             /**
              * Determines if the session has expired by inspection of the expiry.
-             * 
+             *
              * @function hasExpired
              * @private
-             * 
+             *
              * @param {SessionObject} - a session object
              * @returns {boolean} true if the session has expired, false otherwise.
              */
@@ -138,19 +138,19 @@ define([
              * Given a session object, ensure that it is valid, to best of our
              * ability. It serves as the gateway between the externally stored
              * session cookie, and the internally stored session object.
-             * 
+             *
              * It probably should not be the responsibility of the front end
              * to front end to evaluate the session -- that should be conducted
              * by a back-end service -- but this is the way it works now.
-             * 
+             *
              * Validation consists of ensuring that the session object is complete,
              * and that it has not expired. The expiration date derives from the
-             * Globus auth token. The evaluation of this is one of my bigger 
+             * Globus auth token. The evaluation of this is one of my bigger
              * problems.
-             * 
+             *
              * @function validateSession
              * @private
-             * 
+             *
              * @param {Object} - the prospective session object
              * @returns {boolean} - if the session is valid.
              */
@@ -174,13 +174,13 @@ define([
 
             /**
              * Creates an session cookie string from the current session cookie.
-             * 
+             *
              * @todo this is not a very good encoding method; needs to be fixed
              * @todo e.g. a field value which also contains delimiters.
-             * 
+             *
              * @function makeSessionCookie
-             * @private 
-             * 
+             * @private
+             *
              * @returns {string|null} a session object formatted into a string
              * suitable for transport in a cookie.
              */
@@ -194,14 +194,13 @@ define([
             }
             /**
              * Create and set a session cookie in the browser.
-             * 
+             *
              * Adds kbase_session cookie to browser
-             * Adds kbase_narr_session to browser
              * Adds kbase_session object to local storage
-             * 
+             *
              * @function setSessionCookie
              * @private
-             * 
+             *
              * @returns {undefined} nothing
              */
             function setSessionCookie() {
@@ -210,7 +209,7 @@ define([
                     cookieManager.setItem(cookieName, cookieString, cookieMaxAge, '/');
                     if (extraCookieNames) {
                         extraCookieNames.forEach(function (cookieName) {
-                            cookieManager.setItem(cookieName, cookieString, cookieMaxAge, '/');                            
+                            cookieManager.setItem(cookieName, cookieString, cookieMaxAge, '/');
                         });
                     }
                     // Cookie.setItem(narrCookieName, cookieString, cookieMaxAge, '/');
@@ -225,11 +224,11 @@ define([
             /**
              * Forces the session object to be re-imported from the browser
              * cookie. Designed to be used by clients which want to ensure that
-             * they have the very latest session. 
-             * 
+             * they have the very latest session.
+             *
              * @function refreshSession
              * @public
-             * 
+             *
              * @returns {SessionObject} the current session object.
              */
             function refreshSession() {
@@ -241,10 +240,10 @@ define([
              * Returns the "KBase Session", for legacy usage. The legacy method
              * of accessing the session is to work directly with a session object,
              * rather than the api.
-             * 
+             *
              * @function getKBaseSesssion
              * @public
-             * 
+             *
              * @returns {KBaseSessionObject}
              */
             function getKbaseSession() {
@@ -269,19 +268,19 @@ define([
 
             /**
              * Removes all traces of of the session from the users browser
-             * 
+             *
              * @function removeSession
              * @private
-             * 
+             *
              * @returns {undefined} nothing
              */
             function removeSession() {
                 var cookies = cookieManager.getCookies();
                 cookies.forEach(function (cookie) {
-                    cookieManager.removeItem(cookie.name, '/');                    
+                    cookieManager.removeItem(cookie.name, '/');
                     cookieManager.removeItem(cookie.name, '/', '.kbase.us');
                 });
-                
+
 //                Cookie.removeItem(cookieName, '/');
 //                if (extraCookieNames) {
 //                    extraCookieNames.forEach(function (cookieName) {
@@ -299,12 +298,12 @@ define([
 
 
             /**
-             * Attempt to set the internal session object from the given 
+             * Attempt to set the internal session object from the given
              * session object.
-             * 
+             *
              * @function setSession
              * @private
-             * 
+             *
              * @param {SessionObject} obj - a session object
              * @returns {undefined}
              */
@@ -315,15 +314,15 @@ define([
                     sessionObject = null;
                 }
             }
-            
+
             /**
-             * Extract the cookie from the browser environment, parse it, and 
+             * Extract the cookie from the browser environment, parse it, and
              * validate it. This is the canonical interface betweek KBase ui
              * code and browser authentication.
-             * 
+             *
              * @function importSessionFromCookie
              * @private
-             * 
+             *
              * @returns {SessionObject|null} a kbase session object or null
              * if there is no valid session cookie.
              */
@@ -338,7 +337,7 @@ define([
                     return null;
                 }
                 sessionCookie = sessionCookies[0];
-                
+
                 // Ensure that we have the extra cookie names as well.
                 var extraCookiesOk = true;
                 extraCookieNames.forEach(function (name) {
@@ -357,7 +356,7 @@ define([
                     removeSession();
                     return null;
                 }
-                
+
                 // first pass just break out the string into fields.
                 var session = decodeToken(sessionCookie);
 
@@ -399,10 +398,10 @@ define([
             /**
              * Creates a valid standard Session Object from a raw session object
              * provided by Globus.
-             * 
+             *
              * @function importSessionFromAuthObject
              * @private
-             * 
+             *
              * @param {KBaseSessionObject} kbaseSession - the session object
              * returned from the KBase auth server
              * @returns {SessionObject|null} a validated Session Object, or null
@@ -437,20 +436,20 @@ define([
              * typedef {Object} LoginCredentials
              * @property {string} username - the username
              * @property {string} password - the password
-             * 
+             *
              */
 
             /**
              * Authenticate a user give a username and password with the kbase
              * auth service.
              * Named "login" for legacy purposes.
-             * 
+             *
              * @function login
              * @public
-             * 
+             *
              * @param {LoginCredentials} options - a authentication credentials, as would
              * be passed in from a login dialog.
-             * 
+             *
              */
             function login(options) {
                 return new Promise(function (resolve, reject) {
@@ -468,15 +467,15 @@ define([
                         //options.error('Password is empty: It is required for login');
                         return;
                     }
-                    
-                    // Convert the username to lower case, in case the user typed in 
+
+                    // Convert the username to lower case, in case the user typed in
                     // upper case letters.
                     options.username = options.username.toLowerCase();
-                    
+
 
                     // NB: the cookie param determines whether the auth service will
                     // set a cookie or not. The cookie set only includes un and kbase_sessionid.
-                    // It does not include the auth token, amazingly, which is required for all 
+                    // It does not include the auth token, amazingly, which is required for all
                     // service calls.
                     var loginParams = {
                         user_id: options.username,
@@ -591,7 +590,7 @@ define([
             }
             // Setup
 
-            
+
             // API
 
             return {


### PR DESCRIPTION
Removed all old references to that duplicate kbase_narr_session cookie and removed them.

Also removed any ability for the session module to create extra cookies with the duplicate string. There can be only one [cookie]!

There's a parallel patch to kbase-ui that removes the setting that adds the extra cookie.