### PR TITLE
Return proper error object to remove warning

### DIFF
--- a/dist/kb_common/session.js
+++ b/dist/kb_common/session.js
@@ -467,7 +467,7 @@ define([
                             }
                             resolve(makeKbaseSession());
                         } else {
-                            reject(data.error_msg);
+                            reject(new Error(data.error_msg));
                         }
                     },
                     error: function (jqXHR, textStatus) {
@@ -497,7 +497,7 @@ define([
                         }
                         sessionObject = null;
 
-                        reject(errmsg);
+                        reject(new Error(errmsg));
                     }
                 });
             });

--- a/src/js/session.js
+++ b/src/js/session.js
@@ -467,7 +467,7 @@ define([
                             }
                             resolve(makeKbaseSession());
                         } else {
-                            reject(data.error_msg);
+                            reject(new Error(data.error_msg));
                         }
                     },
                     error: function (jqXHR, textStatus) {
@@ -497,7 +497,7 @@ define([
                         }
                         sessionObject = null;
 
-                        reject(errmsg);
+                        reject(new Error(errmsg));
                     }
                 });
             });


### PR DESCRIPTION
- bluebird promises library emits a warning to the log if a promise rejection does not specify a true js error object; this change returns an error object rather than an error message.