### PR TITLE
make service error detection more lenient

### DIFF
--- a/dist/kb_common/jsonRpc/ajax.js
+++ b/dist/kb_common/jsonRpc/ajax.js
@@ -33,7 +33,7 @@ define([
                 reject(new exceptions.TimeoutError(timeout, elapsed, 'Request timeout', xhr));
             };
             xhr.onerror = function () {
-                reject(new exceptions.ConnectionError('Request signalled error', xhr));
+                reject(new exceptions.ConnectionError('Request signaled error', xhr));
             };
             xhr.onabort = function () {
                 reject(new exceptions.AbortError('Request was aborted', xhr));

--- a/dist/kb_common/jsonRpc/jsonRpc-native.js
+++ b/dist/kb_common/jsonRpc/jsonRpc-native.js
@@ -59,7 +59,7 @@ define([
         if (typeof error.message !== 'string' && error.message !== null) {
             return false;
         }
-        if (typeof error.error !== 'string') {
+        if (typeof error.error !== 'string' && error.error !== null) {
             return false;
         }
         if (typeof error.code !== 'number') {

--- a/src/js/jsonRpc/ajax.js
+++ b/src/js/jsonRpc/ajax.js
@@ -33,7 +33,7 @@ define([
                 reject(new exceptions.TimeoutError(timeout, elapsed, 'Request timeout', xhr));
             };
             xhr.onerror = function () {
-                reject(new exceptions.ConnectionError('Request signalled error', xhr));
+                reject(new exceptions.ConnectionError('Request signaled error', xhr));
             };
             xhr.onabort = function () {
                 reject(new exceptions.AbortError('Request was aborted', xhr));

--- a/src/js/jsonRpc/jsonRpc-native.js
+++ b/src/js/jsonRpc/jsonRpc-native.js
@@ -59,7 +59,7 @@ define([
         if (typeof error.message !== 'string' && error.message !== null) {
             return false;
         }
-        if (typeof error.error !== 'string') {
+        if (typeof error.error !== 'string' && error.error !== null) {
             return false;
         }
         if (typeof error.code !== 'number') {


### PR DESCRIPTION
- the error property is apparently missing (null) sometimes, causing the error to be returned as a nonconforming error, which is annoying to handle since things are not in their usual location.